### PR TITLE
Fix update_configuration_during_sync example to work with fivetran debug

### DIFF
--- a/examples/common_patterns/update_configuration_during_sync/README.md
+++ b/examples/common_patterns/update_configuration_during_sync/README.md
@@ -70,6 +70,7 @@ Authentication is done via a two-step session process:
     Example:
     `Authorization: Token <SESSION_TOKEN>`
 - The session token expires after a set duration (`__TOKEN_EXPIRY_TIME`). The connector refreshes the token as needed and updates the configuration using Fivetran REST API.
+- When running via `fivetran debug`, the SDK sets the `FIVETRAN_DEPLOYMENT_MODEL` environment variable to `local_debug`. The connector checks for this and skips the live Fivetran REST API call in that case (logging what would have been sent instead), since there is no real connection to update locally.
 
 
 ## Pagination

--- a/examples/common_patterns/update_configuration_during_sync/connector.py
+++ b/examples/common_patterns/update_configuration_during_sync/connector.py
@@ -117,6 +117,15 @@ def update_configuration(config, new_token):
         }
     }
 
+    # The SDK sets FIVETRAN_DEPLOYMENT_MODEL="local_debug" during `fivetran debug` (as opposed to
+    # "managed_cloud" or "hybrid_cloud" in production). There is no real connection to update in that
+    # case, so skip the live REST API call and log what would have been sent instead. Without this
+    # check, `fivetran debug` always fails here because FIVETRAN_CONNECTION_ID is a placeholder
+    # ("test_connection_id") and fivetran_api_key has no real value to authenticate with.
+    if os.environ.get("FIVETRAN_DEPLOYMENT_MODEL") == "local_debug":
+        log.info(f"[local_debug] Skipping Fivetran REST API call. Would have PATCHed {update_url} with: {payload}")
+        return
+
     headers = {
         "Accept": "application/json;version=2",
         "Authorization": f"Basic {fivetran_api_key}",

--- a/examples/common_patterns/update_configuration_during_sync/connector.py
+++ b/examples/common_patterns/update_configuration_during_sync/connector.py
@@ -123,7 +123,10 @@ def update_configuration(config, new_token):
     # check, `fivetran debug` always fails here because FIVETRAN_CONNECTION_ID is a placeholder
     # ("test_connection_id") and fivetran_api_key has no real value to authenticate with.
     if os.environ.get("FIVETRAN_DEPLOYMENT_MODEL") == "local_debug":
-        log.info(f"[local_debug] Skipping Fivetran REST API call. Would have PATCHed {update_url} with: {payload}")
+        # Log only the config keys being updated, never the values -- config holds secrets
+        # (username, password, fivetran_api_key, token) that must not be written to logs.
+        updated_keys = [entry["key"] for entry in payload["config"]["secrets_list"]]
+        log.info(f"[local_debug] Skipping Fivetran REST API call. Would have PATCHed {update_url} with keys: {updated_keys}")
         return
 
     headers = {

--- a/examples/common_patterns/update_configuration_during_sync/connector.py
+++ b/examples/common_patterns/update_configuration_during_sync/connector.py
@@ -126,7 +126,9 @@ def update_configuration(config, new_token):
         # Log only the config keys being updated, never the values -- config holds secrets
         # (username, password, fivetran_api_key, token) that must not be written to logs.
         updated_keys = [entry["key"] for entry in payload["config"]["secrets_list"]]
-        log.info(f"[local_debug] Skipping Fivetran REST API call. Would have PATCHed {update_url} with keys: {updated_keys}")
+        log.info(
+            f"[local_debug] Skipping Fivetran REST API call. Would have PATCHed {update_url} with keys: {updated_keys}"
+        )
         return
 
     headers = {


### PR DESCRIPTION
### Jira ticket
Closes `<no Jira ticket — small fix found while debugging this example locally; happy to link one if required for merge>`

### Description of Change
The `update_configuration_during_sync` example is documented as "not meant for production use," but it also didn't actually run via `fivetran debug` as shipped, which is confusing for anyone using it to learn the pattern locally.

`update_configuration()` unconditionally PATCHes `https://api.fivetran.com/v1/connections/{FIVETRAN_CONNECTION_ID}`. During `fivetran debug`, `FIVETRAN_CONNECTION_ID` is a placeholder (`test_connection_id`) and there's no real API key to authenticate with, so this call always fails with an uncaught `response.raise_for_status()`, crashing the whole sync before any data is upserted.

The SDK exposes `FIVETRAN_DEPLOYMENT_MODEL` at runtime, set to `local_debug` during `fivetran debug` (vs. `managed_cloud`/`hybrid_cloud` in production — see the [Environment Variables reference](https://fivetran.com/docs/connector-sdk/technical-reference/environment-variables)). This adds a check for that value in `update_configuration()`: when running locally, it skips the live REST API call and logs only the config key names it would have updated (never the values, since `config` holds `username`/`password`/`fivetran_api_key`/`token`). Production behavior (`managed_cloud`/`hybrid_cloud`) is unchanged.

Also added a short note to the README's Authentication section explaining this behavior, since it wasn't otherwise documented.

### Testing
- [x] Tested the connector with `fivetran debug` command — ran end-to-end against the `fivetran-api-playground` mock server after `fivetran reset`, sync succeeded with 20 upserts into the `user` table on each run.
- [x] Confirmed no secret values appear in logs — the local-debug log line prints only config key names (`['username', 'password', 'fivetran_api_key', 'token']`), not values.
- [x] `black --check --diff --line-length 99` and `flake8` both pass clean on the changed file.

### Checklist
- [x] Tested the connector with `fivetran debug` command.
- [x] Added/Updated example-specific README.md file, see [the README template](https://github.com/fivetran/connector_sdk/tree/main/template_connector/README_template.md) for the required structure and guidelines.
- [x] Followed Python Coding Standards, [refer here](https://github.com/fivetran/connector_sdk/blob/main/PYTHON_CODING_STANDARDS.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)